### PR TITLE
fixed listComment signature in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ List comments on a gist ([docs](https://developer.github.com/v3/gists/comments/#
 
 ```js
 // GET /gists/:gist_id/comments
-gists.listComments(options);
+gists.listComments(gist_id, options);
 ```
 
 ### [.edit](index.js#L354)


### PR DESCRIPTION
The listComments signature in the docs were incorrect: updated gists.listComments(options) to gists.listComments(gist_id, options).